### PR TITLE
GitHub: Reference Developer Sanctuary

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -67,3 +67,4 @@ See [the documentation](../docs/credentials.md).
 
 - Some application icons were created by [Icons8](https://github.com/icons8).
 - Many thanks to [Joseph Beattie](https://github.com/josephbeattie) for creating our current logo.
+- Join [Developer Sanctuary](https://dsc.gg/devsanx) to learn more about our project!


### PR DESCRIPTION
Required by @FireCubeStudios

[`Developer Sanctuary > #casual > 🗨️`](https://discord.com/channels/714581497222398064/768464221100179536/1300557028766384139)

> link to dev sanx needed for current ping role and channel category right now
> at least in the github