### PR TITLE
Automate Microsoft Store submissions and listing localization

### DIFF
--- a/.github/scripts/Merge-MicrosoftStoreListings.ps1
+++ b/.github/scripts/Merge-MicrosoftStoreListings.ps1
@@ -65,6 +65,28 @@ if ($null -eq $listingsProperty -or $null -eq $listingsProperty.Value)
 
 $locales = @($localeConfiguration.PSObject.Properties["locales"].Value)
 $defaultLocale = [string]$localeConfiguration.PSObject.Properties["defaultLocale"].Value
+$configuredLocaleSet = [Collections.Generic.HashSet[string]]::new(
+    [StringComparer]::OrdinalIgnoreCase
+)
+
+foreach ($locale in $locales)
+{
+    $configuredLocaleSet.Add([string]$locale) | Out-Null
+}
+
+$submissionLocales = @($listingsProperty.Value.PSObject.Properties.Name)
+$unmanagedLocales = @(
+    $submissionLocales |
+        Where-Object { -not $configuredLocaleSet.Contains($_) }
+)
+
+if ($unmanagedLocales.Count -gt 0)
+{
+    throw @"
+The Partner Center draft contains Store listings that are not configured in locales.json: $($unmanagedLocales -join ', ').
+Remove those languages from the draft, or add their source-controlled listings and screenshots before rerunning this workflow.
+"@
+}
 
 foreach ($locale in $locales)
 {

--- a/.github/scripts/Merge-MicrosoftStoreListings.ps1
+++ b/.github/scripts/Merge-MicrosoftStoreListings.ps1
@@ -1,0 +1,125 @@
+# Copyright (c) 2026 0x5BFA
+# Licensed under the MIT License. See the LICENSE.
+
+#Requires -Version 7.4
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$SubmissionPath,
+
+    [Parameter(Mandatory)]
+    [string]$ListingsPath,
+
+    [Parameter(Mandatory)]
+    [string]$LocalesPath,
+
+    [Parameter(Mandatory)]
+    [string]$OutputPath,
+
+    [string]$ReleaseNotes = ""
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 3.0
+
+function Set-JsonProperty
+{
+    param(
+        [Parameter(Mandatory)]
+        [psobject]$InputObject,
+
+        [Parameter(Mandatory)]
+        [string]$Name,
+
+        [AllowNull()]
+        [object]$Value
+    )
+
+    if ($InputObject.PSObject.Properties.Name -contains $Name)
+    {
+        $InputObject.$Name = $Value
+    }
+    else
+    {
+        $InputObject | Add-Member -NotePropertyName $Name -NotePropertyValue $Value
+    }
+}
+
+if (-not (Test-Path -LiteralPath $SubmissionPath -PathType Leaf))
+{
+    throw "The Store submission file does not exist: $SubmissionPath"
+}
+
+$validationScriptPath = Join-Path $PSScriptRoot "Validate-MicrosoftStoreListings.ps1"
+& $validationScriptPath -ListingsPath $ListingsPath -LocalesPath $LocalesPath
+
+$localeConfiguration = Get-Content -LiteralPath $LocalesPath -Raw | ConvertFrom-Json -Depth 10
+$submission = Get-Content -LiteralPath $SubmissionPath -Raw | ConvertFrom-Json -Depth 100
+$listingsProperty = $submission.PSObject.Properties["listings"]
+
+if ($null -eq $listingsProperty -or $null -eq $listingsProperty.Value)
+{
+    throw "The Store submission does not contain any listings."
+}
+
+$locales = @($localeConfiguration.PSObject.Properties["locales"].Value)
+$defaultLocale = [string]$localeConfiguration.PSObject.Properties["defaultLocale"].Value
+
+foreach ($locale in $locales)
+{
+    $submissionListing = $listingsProperty.Value.PSObject.Properties |
+        Where-Object { $_.Name.Equals($locale, [StringComparison]::OrdinalIgnoreCase) } |
+        Select-Object -First 1
+
+    if ($null -eq $submissionListing)
+    {
+        throw @"
+The Partner Center draft does not contain a '$locale' listing.
+Add the language and its screenshots in Partner Center once, then rerun this workflow.
+"@
+    }
+
+    $baseListingProperty = $submissionListing.Value.PSObject.Properties["baseListing"]
+
+    if ($null -eq $baseListingProperty -or $null -eq $baseListingProperty.Value)
+    {
+        throw "The Partner Center '$locale' listing does not contain baseListing metadata."
+    }
+
+    $baseListing = $baseListingProperty.Value
+    $listingPath = Join-Path $ListingsPath "$locale.json"
+    $localizedListing = Get-Content -LiteralPath $listingPath -Raw | ConvertFrom-Json -Depth 20
+
+    foreach ($property in $localizedListing.PSObject.Properties)
+    {
+        Set-JsonProperty -InputObject $baseListing -Name $property.Name -Value $property.Value
+    }
+
+    if ($locale.Equals($defaultLocale, [StringComparison]::OrdinalIgnoreCase) -and
+        -not [string]::IsNullOrWhiteSpace($ReleaseNotes))
+    {
+        if ($ReleaseNotes.Length -gt 1500)
+        {
+            throw "ReleaseNotes exceeds the 1500 character limit."
+        }
+
+        Set-JsonProperty -InputObject $baseListing -Name "releaseNotes" -Value $ReleaseNotes
+    }
+}
+
+$outputDirectory = Split-Path -Parent $OutputPath
+
+if (-not [string]::IsNullOrWhiteSpace($outputDirectory))
+{
+    [IO.Directory]::CreateDirectory($outputDirectory) | Out-Null
+}
+
+$updatedJson = $submission | ConvertTo-Json -Depth 100
+[IO.File]::WriteAllText(
+    $OutputPath,
+    $updatedJson + [Environment]::NewLine,
+    [Text.UTF8Encoding]::new($false)
+)
+
+Write-Host "Merged $($locales.Count) localized Store listing(s)."

--- a/.github/scripts/Run-MicrosoftStoreSubmission.ps1
+++ b/.github/scripts/Run-MicrosoftStoreSubmission.ps1
@@ -1,0 +1,35 @@
+# Copyright (c) 2024 0x5BFA
+# Licensed under the MIT License. See the LICENSE.
+
+#Requires -Version 7.4
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 3.0
+
+$submit = [Convert]::ToBoolean($env:STORE_SUBMIT)
+$replaceExistingDraft = [Convert]::ToBoolean($env:STORE_REPLACE_EXISTING_DRAFT)
+
+Write-Host "Invoking Microsoft Store submission script (submit=$submit, replaceExistingDraft=$replaceExistingDraft)."
+
+$submissionScript = Join-Path $PSScriptRoot "SubmitTo-MicrosoftStore.ps1"
+
+$submissionParameters = @{
+    StorePackagePath = $env:STORE_PACKAGE_PATH
+    StoreListingsPath = $env:STORE_LISTINGS_DIR
+    StoreLocalesPath = $env:STORE_LOCALES_PATH
+    PartnerCenterClientId = $env:PARTNER_CENTER_CLIENT_ID
+    PartnerCenterClientSecret = $env:PARTNER_CENTER_CLIENT_SECRET
+    PartnerCenterSellerId = $env:PARTNER_CENTER_SELLER_ID
+    PartnerCenterStoreId = $env:STORE_PRODUCT_ID
+    PartnerCenterTenantId = $env:PARTNER_CENTER_TENANT_ID
+    Submit = $submit
+    ReplaceExistingDraft = $replaceExistingDraft
+    ReleaseNotes = $env:STORE_RELEASE_NOTES
+    FlightId = $env:STORE_FLIGHT_ID
+    PackageRolloutPercentage = $env:STORE_ROLLOUT_PERCENTAGE
+}
+
+& $submissionScript @submissionParameters

--- a/.github/scripts/SubmitTo-MicrosoftStore.ps1
+++ b/.github/scripts/SubmitTo-MicrosoftStore.ps1
@@ -98,7 +98,7 @@ function Get-PropertyByName
         Select-Object -First 1
 }
 
-function ConvertTo-ComparableJson
+function Normalize-ComparableValue
 {
     param(
         [AllowNull()]
@@ -107,10 +107,40 @@ function ConvertTo-ComparableJson
 
     if ($null -eq $Value)
     {
+        return $null
+    }
+
+    if ($Value -is [string])
+    {
+        return [regex]::Replace($Value, '\s+', ' ').Trim()
+    }
+
+    if ($Value -is [System.Collections.IEnumerable] -and
+        $Value -isnot [System.Collections.IDictionary])
+    {
+        return @($Value | ForEach-Object {
+            Normalize-ComparableValue -Value $_
+        })
+    }
+
+    return $Value
+}
+
+function ConvertTo-ComparableJson
+{
+    param(
+        [AllowNull()]
+        [object]$Value
+    )
+
+    $normalizedValue = Normalize-ComparableValue -Value $Value
+
+    if ($null -eq $normalizedValue)
+    {
         return "null"
     }
 
-    return $Value | ConvertTo-Json -Depth 100 -Compress
+    return $normalizedValue | ConvertTo-Json -Depth 100 -Compress
 }
 
 function Test-UpdatedSubmission

--- a/.github/scripts/SubmitTo-MicrosoftStore.ps1
+++ b/.github/scripts/SubmitTo-MicrosoftStore.ps1
@@ -1,22 +1,114 @@
 # Copyright (c) 2024 0x5BFA
 # Licensed under the MIT License. See the LICENSE.
 
+#Requires -Version 7.4
+
+[CmdletBinding()]
 param(
-    [string]$StorePackagePath = "",
-    [string]$PartnerCenterClientId = "",
-    [string]$PartnerCenterClientSecret = "",
-    [string]$PartnerCenterSellerId = "",
-    [string]$PartnerCenterStoreId = "",
-    [string]$PartnerCenterTenantId = "",
+    [Parameter(Mandatory)]
+    [string]$StorePackagePath,
+
+    [Parameter(Mandatory)]
+    [string]$StoreListingsPath,
+
+    [Parameter(Mandatory)]
+    [string]$StoreLocalesPath,
+
+    [Parameter(Mandatory)]
+    [string]$PartnerCenterClientId,
+
+    [Parameter(Mandatory)]
+    [string]$PartnerCenterClientSecret,
+
+    [Parameter(Mandatory)]
+    [string]$PartnerCenterSellerId,
+
+    [Parameter(Mandatory)]
+    [string]$PartnerCenterStoreId,
+
+    [Parameter(Mandatory)]
+    [string]$PartnerCenterTenantId,
+
     [bool]$Submit = $false,
+
+    [bool]$ReplaceExistingDraft = $false,
+
+    [string]$ReleaseNotes = "",
+
     [string]$FlightId = "",
+
     [string]$PackageRolloutPercentage = ""
 )
 
 $ErrorActionPreference = "Stop"
+Set-StrictMode -Version 3.0
+
+function Invoke-MsStore
+{
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$Arguments
+    )
+
+    & msstore @Arguments
+
+    if ($LASTEXITCODE -ne 0)
+    {
+        throw "msstore $($Arguments[0]) failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Invoke-MsStoreJson
+{
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$Arguments
+    )
+
+    $output = & msstore @Arguments | Out-String
+
+    if ($LASTEXITCODE -ne 0)
+    {
+        throw "msstore $($Arguments[0]) failed with exit code $LASTEXITCODE."
+    }
+
+    $jsonStart = $output.IndexOf("{", [StringComparison]::Ordinal)
+    $jsonEnd = $output.LastIndexOf("}", [StringComparison]::Ordinal)
+
+    if ($jsonStart -lt 0 -or $jsonEnd -lt $jsonStart)
+    {
+        throw "msstore $($Arguments[0]) did not return a JSON object."
+    }
+
+    return $output.Substring($jsonStart, $jsonEnd - $jsonStart + 1)
+}
+
+function Test-PendingSubmission
+{
+    if ([string]::IsNullOrWhiteSpace($FlightId))
+    {
+        $applicationJson = Invoke-MsStoreJson -Arguments @(
+            "apps",
+            "get",
+            $PartnerCenterStoreId
+        )
+        $application = $applicationJson | ConvertFrom-Json -Depth 100
+        $pendingSubmission = $application.PSObject.Properties["pendingApplicationSubmission"]
+        return $null -ne $pendingSubmission -and $null -ne $pendingSubmission.Value
+    }
+
+    $flightJson = Invoke-MsStoreJson -Arguments @(
+        "flights",
+        "get",
+        $PartnerCenterStoreId,
+        $FlightId
+    )
+    $flight = $flightJson | ConvertFrom-Json -Depth 100
+    $pendingSubmission = $flight.PSObject.Properties["pendingFlightSubmission"]
+    return $null -ne $pendingSubmission -and $null -ne $pendingSubmission.Value
+}
 
 $requiredValues = @{
-    StorePackagePath            = $StorePackagePath
     PartnerCenterClientId       = $PartnerCenterClientId
     PartnerCenterClientSecret   = $PartnerCenterClientSecret
     PartnerCenterSellerId       = $PartnerCenterSellerId
@@ -37,31 +129,51 @@ if (-not (Test-Path -LiteralPath $StorePackagePath -PathType Leaf))
     throw "The Store package does not exist: $StorePackagePath"
 }
 
-msstore reconfigure `
-    --tenantId $PartnerCenterTenantId `
-    --sellerId $PartnerCenterSellerId `
-    --clientId $PartnerCenterClientId `
-    --clientSecret $PartnerCenterClientSecret
-
-if ($LASTEXITCODE -ne 0)
+if (-not (Test-Path -LiteralPath $StoreListingsPath -PathType Container))
 {
-    throw "msstore reconfigure failed with exit code $LASTEXITCODE."
+    throw "The Store listings directory does not exist: $StoreListingsPath"
+}
+
+if (-not (Test-Path -LiteralPath $StoreLocalesPath -PathType Leaf))
+{
+    throw "The Store locales file does not exist: $StoreLocalesPath"
+}
+
+Invoke-MsStore -Arguments @(
+    "reconfigure",
+    "--tenantId",
+    $PartnerCenterTenantId,
+    "--sellerId",
+    $PartnerCenterSellerId,
+    "--clientId",
+    $PartnerCenterClientId,
+    "--clientSecret",
+    $PartnerCenterClientSecret
+)
+
+$hasPendingSubmission = Test-PendingSubmission
+
+if ($hasPendingSubmission -and -not $ReplaceExistingDraft)
+{
+    throw @"
+Partner Center already has a pending submission for this target.
+The Microsoft Store CLI replaces pending submissions when publishing a package.
+Review or remove the draft in Partner Center, or rerun with ReplaceExistingDraft enabled.
+"@
+}
+
+if ($hasPendingSubmission)
+{
+    Write-Warning "The existing Partner Center draft will be replaced."
 }
 
 $publishArgs = @(
     "publish",
     $StorePackagePath,
     "--appId",
-    $PartnerCenterStoreId
+    $PartnerCenterStoreId,
+    "--noCommit"
 )
-
-Write-Host "Publishing package '$StorePackagePath' to Microsoft Store app '$PartnerCenterStoreId'."
-
-if (-not $Submit)
-{
-    $publishArgs += "--noCommit"
-    Write-Host "The submission will stay as a draft because Submit is false."
-}
 
 if (-not [string]::IsNullOrWhiteSpace($FlightId))
 {
@@ -73,9 +185,94 @@ if (-not [string]::IsNullOrWhiteSpace($PackageRolloutPercentage))
     $publishArgs += @("--packageRolloutPercentage", $PackageRolloutPercentage)
 }
 
-msstore @publishArgs
+Write-Host "Uploading package '$StorePackagePath' to Microsoft Store app '$PartnerCenterStoreId'."
+Invoke-MsStore -Arguments $publishArgs
 
-if ($LASTEXITCODE -ne 0)
+if (-not [string]::IsNullOrWhiteSpace($FlightId))
 {
-    throw "msstore publish failed with exit code $LASTEXITCODE."
+    if (-not $Submit)
+    {
+        Write-Host "The flight submission is ready and will remain in draft state."
+        return
+    }
+
+    Invoke-MsStore -Arguments @(
+        "flights",
+        "submission",
+        "publish",
+        $PartnerCenterStoreId,
+        $FlightId
+    )
+    Invoke-MsStore -Arguments @(
+        "flights",
+        "submission",
+        "poll",
+        $PartnerCenterStoreId,
+        $FlightId
+    )
+    return
+}
+
+$tempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+$tempPath = Join-Path $tempRoot "FluentHub-MicrosoftStore-$([Guid]::NewGuid().ToString('N'))"
+[IO.Directory]::CreateDirectory($tempPath) | Out-Null
+
+try
+{
+    $submissionPath = Join-Path $tempPath "submission.json"
+    $updatedSubmissionPath = Join-Path $tempPath "submission.updated.json"
+    $submissionJson = Invoke-MsStoreJson -Arguments @(
+        "submission",
+        "get",
+        $PartnerCenterStoreId
+    )
+    [IO.File]::WriteAllText(
+        $submissionPath,
+        $submissionJson + [Environment]::NewLine,
+        [Text.UTF8Encoding]::new($false)
+    )
+
+    $mergeScriptPath = Join-Path $PSScriptRoot "Merge-MicrosoftStoreListings.ps1"
+    & $mergeScriptPath `
+        -SubmissionPath $submissionPath `
+        -ListingsPath $StoreListingsPath `
+        -LocalesPath $StoreLocalesPath `
+        -OutputPath $updatedSubmissionPath `
+        -ReleaseNotes $ReleaseNotes
+
+    $updatedMetadata = Get-Content -LiteralPath $updatedSubmissionPath -Raw
+    Invoke-MsStore -Arguments @(
+        "submission",
+        "updateMetadata",
+        $PartnerCenterStoreId,
+        $updatedMetadata
+    )
+
+    if (-not $Submit)
+    {
+        Write-Host "The package and localized listings are ready and will remain in draft state."
+        return
+    }
+
+    Invoke-MsStore -Arguments @(
+        "submission",
+        "publish",
+        $PartnerCenterStoreId
+    )
+    Invoke-MsStore -Arguments @(
+        "submission",
+        "poll",
+        $PartnerCenterStoreId
+    )
+}
+finally
+{
+    $resolvedTempPath = [IO.Path]::GetFullPath($tempPath)
+
+    if ($resolvedTempPath.StartsWith($tempRoot, [StringComparison]::OrdinalIgnoreCase) -and
+        [IO.Path]::GetFileName($resolvedTempPath).StartsWith("FluentHub-MicrosoftStore-", [StringComparison]::Ordinal) -and
+        [IO.Directory]::Exists($resolvedTempPath))
+    {
+        [IO.Directory]::Delete($resolvedTempPath, $true)
+    }
 }

--- a/.github/scripts/SubmitTo-MicrosoftStore.ps1
+++ b/.github/scripts/SubmitTo-MicrosoftStore.ps1
@@ -83,6 +83,137 @@ function Invoke-MsStoreJson
     return $output.Substring($jsonStart, $jsonEnd - $jsonStart + 1)
 }
 
+function Get-PropertyByName
+{
+    param(
+        [Parameter(Mandatory)]
+        [psobject]$InputObject,
+
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    return $InputObject.PSObject.Properties |
+        Where-Object { $_.Name.Equals($Name, [StringComparison]::OrdinalIgnoreCase) } |
+        Select-Object -First 1
+}
+
+function ConvertTo-ComparableJson
+{
+    param(
+        [AllowNull()]
+        [object]$Value
+    )
+
+    if ($null -eq $Value)
+    {
+        return "null"
+    }
+
+    return $Value | ConvertTo-Json -Depth 100 -Compress
+}
+
+function Test-UpdatedSubmission
+{
+    $submissionJson = Invoke-MsStoreJson -Arguments @(
+        "submission",
+        "get",
+        $PartnerCenterStoreId
+    )
+    $submission = $submissionJson | ConvertFrom-Json -Depth 100
+
+    $applicationPackagesProperty = Get-PropertyByName `
+        -InputObject $submission `
+        -Name "ApplicationPackages"
+
+    if ($null -eq $applicationPackagesProperty)
+    {
+        throw "The updated submission does not contain ApplicationPackages."
+    }
+
+    $expectedPackageName = [IO.Path]::GetFileName($StorePackagePath)
+    $packageMatch = $null
+
+    foreach ($applicationPackage in @($applicationPackagesProperty.Value))
+    {
+        $fileNameProperty = Get-PropertyByName `
+            -InputObject $applicationPackage `
+            -Name "FileName"
+
+        if ($null -ne $fileNameProperty -and
+            [string]$fileNameProperty.Value -ieq $expectedPackageName)
+        {
+            $packageMatch = $applicationPackage
+            break
+        }
+    }
+
+    if ($null -eq $packageMatch)
+    {
+        throw "The updated submission does not contain the uploaded package '$expectedPackageName'."
+    }
+
+    Write-Host "Verified Store package in submission: $expectedPackageName"
+
+    $listingsProperty = Get-PropertyByName `
+        -InputObject $submission `
+        -Name "Listings"
+
+    if ($null -eq $listingsProperty)
+    {
+        throw "The updated submission does not contain Listings."
+    }
+
+    $localeConfiguration = Get-Content -LiteralPath $StoreLocalesPath -Raw | ConvertFrom-Json -Depth 10
+    $locales = @($localeConfiguration.PSObject.Properties["locales"].Value)
+
+    foreach ($locale in $locales)
+    {
+        $submissionListing = $listingsProperty.Value.PSObject.Properties |
+            Where-Object { $_.Name.Equals($locale, [StringComparison]::OrdinalIgnoreCase) } |
+            Select-Object -First 1
+
+        if ($null -eq $submissionListing)
+        {
+            throw "The updated submission does not contain the '$locale' listing."
+        }
+
+        $baseListingProperty = Get-PropertyByName `
+            -InputObject $submissionListing.Value `
+            -Name "BaseListing"
+
+        if ($null -eq $baseListingProperty)
+        {
+            throw "The updated '$locale' listing does not contain BaseListing."
+        }
+
+        $listingPath = Join-Path $StoreListingsPath "$locale.json"
+        $localizedListing = Get-Content -LiteralPath $listingPath -Raw | ConvertFrom-Json -Depth 20
+
+        foreach ($property in $localizedListing.PSObject.Properties)
+        {
+            $updatedProperty = Get-PropertyByName `
+                -InputObject $baseListingProperty.Value `
+                -Name $property.Name
+
+            if ($null -eq $updatedProperty)
+            {
+                throw "The updated '$locale' listing does not contain '$($property.Name)'."
+            }
+
+            $expectedValue = ConvertTo-ComparableJson -Value $property.Value
+            $actualValue = ConvertTo-ComparableJson -Value $updatedProperty.Value
+
+            if ($expectedValue -cne $actualValue)
+            {
+                throw "The updated '$locale' listing property '$($property.Name)' does not match the repository listing."
+            }
+        }
+
+        Write-Host "Verified Store listing in submission: $locale"
+    }
+}
+
 function Test-PendingSubmission
 {
     if ([string]::IsNullOrWhiteSpace($FlightId))
@@ -247,6 +378,27 @@ try
         $PartnerCenterStoreId,
         $updatedMetadata
     )
+
+    $verificationAttempts = 3
+
+    for ($attempt = 1; $attempt -le $verificationAttempts; $attempt++)
+    {
+        try
+        {
+            Test-UpdatedSubmission
+            break
+        }
+        catch
+        {
+            if ($attempt -eq $verificationAttempts)
+            {
+                throw
+            }
+
+            Write-Warning "Store submission verification attempt $attempt failed: $($_.Exception.Message). Retrying."
+            Start-Sleep -Seconds 5
+        }
+    }
 
     if (-not $Submit)
     {

--- a/.github/scripts/SubmitTo-MicrosoftStore.ps1
+++ b/.github/scripts/SubmitTo-MicrosoftStore.ps1
@@ -40,7 +40,7 @@ param(
     [string]$PackageRolloutPercentage = "",
 
     [ValidateRange(1, 3600)]
-    [int]$PackageValidationTimeoutSeconds = 300,
+    [int]$PackageValidationTimeoutSeconds = 900,
 
     [ValidateRange(1, 3600)]
     [int]$SubmissionVerificationTimeoutSeconds = 300
@@ -512,65 +512,98 @@ Invoke-MsStore -Arguments @(
 )
 
 $hasPendingSubmission = Test-PendingSubmission
+$submissionJson = $null
+$expectedPackageName = [IO.Path]::GetFileName($StorePackagePath)
 
 if ($hasPendingSubmission -and -not $ReplaceExistingDraft)
 {
-    throw @"
-Partner Center already has a pending submission for this target.
-The Microsoft Store CLI replaces pending submissions when publishing a package.
-Review or remove the draft in Partner Center, or rerun with ReplaceExistingDraft enabled.
-"@
-}
-
-if ($hasPendingSubmission)
-{
-    Write-Warning "The existing Partner Center draft will be replaced."
-}
-
-$publishArgs = @(
-    "publish",
-    $StorePackagePath,
-    "--appId",
-    $PartnerCenterStoreId,
-    "--noCommit"
-)
-
-if (-not [string]::IsNullOrWhiteSpace($FlightId))
-{
-    $publishArgs += @("--flightId", $FlightId)
-}
-
-if (-not [string]::IsNullOrWhiteSpace($PackageRolloutPercentage))
-{
-    $publishArgs += @("--packageRolloutPercentage", $PackageRolloutPercentage)
-}
-
-Write-Host "Uploading package '$StorePackagePath' to Microsoft Store app '$PartnerCenterStoreId'."
-Invoke-MsStore -Arguments $publishArgs
-
-if (-not [string]::IsNullOrWhiteSpace($FlightId))
-{
-    if (-not $Submit)
+    if (-not [string]::IsNullOrWhiteSpace($FlightId))
     {
-        Write-Host "The flight submission is ready and will remain in draft state."
+        throw @"
+Partner Center already has a pending flight submission for this target.
+Review or remove the draft, or rerun with ReplaceExistingDraft enabled.
+"@
+    }
+
+    $submissionJson = Invoke-MsStoreJson -Arguments @(
+        "submission",
+        "get",
+        $PartnerCenterStoreId
+    )
+    $pendingSubmission = $submissionJson | ConvertFrom-Json -Depth 100
+    $pendingPackage = Get-ApplicationPackage `
+        -Submission $pendingSubmission `
+        -FileName $expectedPackageName
+
+    if ($null -eq $pendingPackage)
+    {
+        throw @"
+Partner Center already has a pending submission, but it does not contain '$expectedPackageName'.
+Review the draft, or rerun with ReplaceExistingDraft enabled only if it can be discarded.
+"@
+    }
+
+    Write-Host "Resuming the existing Partner Center draft for package '$expectedPackageName'."
+}
+
+if (-not $hasPendingSubmission -or $ReplaceExistingDraft)
+{
+    if ($hasPendingSubmission)
+    {
+        Write-Warning "The existing Partner Center draft will be replaced."
+    }
+
+    $publishArgs = @(
+        "publish",
+        $StorePackagePath,
+        "--appId",
+        $PartnerCenterStoreId,
+        "--noCommit"
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($FlightId))
+    {
+        $publishArgs += @("--flightId", $FlightId)
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($PackageRolloutPercentage))
+    {
+        $publishArgs += @("--packageRolloutPercentage", $PackageRolloutPercentage)
+    }
+
+    Write-Host "Uploading package '$StorePackagePath' to Microsoft Store app '$PartnerCenterStoreId'."
+    Invoke-MsStore -Arguments $publishArgs
+
+    if (-not [string]::IsNullOrWhiteSpace($FlightId))
+    {
+        if (-not $Submit)
+        {
+            Write-Host "The flight submission is ready and will remain in draft state."
+            return
+        }
+
+        Invoke-MsStore -Arguments @(
+            "flights",
+            "submission",
+            "publish",
+            $PartnerCenterStoreId,
+            $FlightId
+        )
+        Invoke-MsStore -Arguments @(
+            "flights",
+            "submission",
+            "poll",
+            $PartnerCenterStoreId,
+            $FlightId
+        )
         return
     }
 
-    Invoke-MsStore -Arguments @(
-        "flights",
+    $submissionJson = Invoke-MsStoreJson -Arguments @(
         "submission",
-        "publish",
-        $PartnerCenterStoreId,
-        $FlightId
+        "get",
+        $PartnerCenterStoreId
     )
-    Invoke-MsStore -Arguments @(
-        "flights",
-        "submission",
-        "poll",
-        $PartnerCenterStoreId,
-        $FlightId
-    )
-    return
 }
 
 $tempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
@@ -581,6 +614,20 @@ try
 {
     $submissionPath = Join-Path $tempPath "submission.json"
     $updatedSubmissionPath = Join-Path $tempPath "submission.updated.json"
+
+    if ([string]::IsNullOrWhiteSpace($submissionJson))
+    {
+        throw "The pending Store submission could not be retrieved."
+    }
+
+    Write-Host "Requesting Partner Center package validation for '$expectedPackageName'."
+    Invoke-MsStore -Arguments @(
+        "submission",
+        "updateMetadata",
+        $PartnerCenterStoreId,
+        $submissionJson
+    )
+
     $submissionJson = Wait-MicrosoftStorePackageValidation
     [IO.File]::WriteAllText(
         $submissionPath,

--- a/.github/scripts/SubmitTo-MicrosoftStore.ps1
+++ b/.github/scripts/SubmitTo-MicrosoftStore.ps1
@@ -639,18 +639,7 @@ try
         throw "The pending Store submission could not be retrieved."
     }
 
-    $validationSubmission = $submissionJson | ConvertFrom-Json -Depth 100
-    $validationSubmissionJson = $validationSubmission |
-        ConvertTo-Json -Depth 100 -Compress
-
-    Write-Host "Requesting Partner Center package validation for '$expectedPackageName'."
-    Invoke-MsStore -Arguments @(
-        "submission",
-        "updateMetadata",
-        $PartnerCenterStoreId,
-        $validationSubmissionJson
-    )
-
+    Write-Host "Checking Partner Center package staging for '$expectedPackageName'."
     $submissionJson = Wait-MicrosoftStorePackageReadiness
     [IO.File]::WriteAllText(
         $submissionPath,
@@ -678,7 +667,9 @@ try
 
     if (-not $Submit)
     {
-        Write-Host "The package and localized listings are ready and will remain in draft state."
+        Write-Host @"
+The package and localized listings are staged in the Submission API and will remain in PendingCommit state. The Partner Center editor can continue to show its previous values until the submission is committed.
+"@
         return
     }
 

--- a/.github/scripts/SubmitTo-MicrosoftStore.ps1
+++ b/.github/scripts/SubmitTo-MicrosoftStore.ps1
@@ -37,7 +37,13 @@ param(
 
     [string]$FlightId = "",
 
-    [string]$PackageRolloutPercentage = ""
+    [string]$PackageRolloutPercentage = "",
+
+    [ValidateRange(1, 3600)]
+    [int]$PackageValidationTimeoutSeconds = 300,
+
+    [ValidateRange(1, 3600)]
+    [int]$SubmissionVerificationTimeoutSeconds = 300
 )
 
 $ErrorActionPreference = "Stop"
@@ -143,6 +149,181 @@ function ConvertTo-ComparableJson
     return $normalizedValue | ConvertTo-Json -Depth 100 -Compress
 }
 
+function Get-ApplicationPackage
+{
+    param(
+        [Parameter(Mandatory)]
+        [psobject]$Submission,
+
+        [Parameter(Mandatory)]
+        [string]$FileName
+    )
+
+    $applicationPackagesProperty = Get-PropertyByName `
+        -InputObject $Submission `
+        -Name "ApplicationPackages"
+
+    if ($null -eq $applicationPackagesProperty)
+    {
+        return $null
+    }
+
+    foreach ($applicationPackage in @($applicationPackagesProperty.Value))
+    {
+        $fileNameProperty = Get-PropertyByName `
+            -InputObject $applicationPackage `
+            -Name "FileName"
+
+        if ($null -ne $fileNameProperty -and
+            [string]$fileNameProperty.Value -ieq $FileName)
+        {
+            return $applicationPackage
+        }
+    }
+
+    return $null
+}
+
+function Assert-SubmissionLocales
+{
+    param(
+        [Parameter(Mandatory)]
+        [psobject]$Submission,
+
+        [Parameter(Mandatory)]
+        [string[]]$ConfiguredLocales
+    )
+
+    $listingsProperty = Get-PropertyByName `
+        -InputObject $Submission `
+        -Name "Listings"
+
+    if ($null -eq $listingsProperty -or $null -eq $listingsProperty.Value)
+    {
+        throw "The Store submission does not contain Listings."
+    }
+
+    $configuredLocaleSet = [Collections.Generic.HashSet[string]]::new(
+        [StringComparer]::OrdinalIgnoreCase
+    )
+
+    foreach ($locale in $ConfiguredLocales)
+    {
+        $configuredLocaleSet.Add($locale) | Out-Null
+    }
+
+    $submissionLocales = @($listingsProperty.Value.PSObject.Properties.Name)
+    $unmanagedLocales = @(
+        $submissionLocales |
+            Where-Object { -not $configuredLocaleSet.Contains($_) }
+    )
+    $missingLocales = @(
+        $ConfiguredLocales |
+            Where-Object { $submissionLocales -inotcontains $_ }
+    )
+
+    if ($unmanagedLocales.Count -gt 0 -or $missingLocales.Count -gt 0)
+    {
+        $expectedLocales = @($ConfiguredLocales | Sort-Object) -join ", "
+        $actualLocales = @($submissionLocales | Sort-Object) -join ", "
+        throw "The Store listing locale set does not match locales.json. Expected: [$expectedLocales]. Actual: [$actualLocales]."
+    }
+
+    return $listingsProperty.Value
+}
+
+function Wait-MicrosoftStorePackageValidation
+{
+    $expectedPackageName = [IO.Path]::GetFileName($StorePackagePath)
+    $deadline = [DateTime]::UtcNow.AddSeconds($PackageValidationTimeoutSeconds)
+    $delaySeconds = 5
+    $attempt = 0
+    $lastError = "The package has not been returned by Partner Center."
+
+    while ($true)
+    {
+        $attempt++
+
+        try
+        {
+            $submissionJson = Invoke-MsStoreJson -Arguments @(
+                "submission",
+                "get",
+                $PartnerCenterStoreId
+            )
+            $submission = $submissionJson | ConvertFrom-Json -Depth 100
+            $applicationPackage = Get-ApplicationPackage `
+                -Submission $submission `
+                -FileName $expectedPackageName
+
+            if ($null -eq $applicationPackage)
+            {
+                $lastError = "The draft does not contain '$expectedPackageName'."
+            }
+            else
+            {
+                $versionProperty = Get-PropertyByName `
+                    -InputObject $applicationPackage `
+                    -Name "Version"
+                $languagesProperty = Get-PropertyByName `
+                    -InputObject $applicationPackage `
+                    -Name "Languages"
+                $version = ""
+                $languages = @()
+
+                if ($null -ne $versionProperty)
+                {
+                    $version = [string]$versionProperty.Value
+                }
+
+                if ($null -ne $languagesProperty)
+                {
+                    $languages = @(
+                        $languagesProperty.Value |
+                            Where-Object {
+                                $_ -is [string] -and
+                                -not [string]::IsNullOrWhiteSpace($_)
+                            }
+                    )
+                }
+
+                if (-not [string]::IsNullOrWhiteSpace($version) -and
+                    $languages.Count -gt 0)
+                {
+                    Write-Host @"
+Store package validation completed: $expectedPackageName (version=$version, languages=$($languages.Count)).
+"@
+                    return $submissionJson
+                }
+
+                $lastError = @"
+Partner Center has not finished validating '$expectedPackageName' (version='$version', languages=$($languages.Count)).
+"@.Trim()
+            }
+        }
+        catch
+        {
+            $lastError = $_.Exception.Message
+        }
+
+        $remainingSeconds = [int][Math]::Floor(
+            ($deadline - [DateTime]::UtcNow).TotalSeconds
+        )
+
+        if ($remainingSeconds -le 0)
+        {
+            throw "Timed out waiting for Store package validation after $attempt attempt(s). Last result: $lastError"
+        }
+
+        $sleepSeconds = [Math]::Min($delaySeconds, $remainingSeconds)
+        Write-Warning @"
+Store package validation attempt $attempt is not ready: $lastError Retrying in $sleepSeconds second(s).
+"@
+        Start-Sleep -Seconds $sleepSeconds
+        $delaySeconds = [Math]::Min($delaySeconds * 2, 30)
+    }
+}
+
 function Test-UpdatedSubmission
 {
     $submissionJson = Invoke-MsStoreJson -Arguments @(
@@ -152,31 +333,10 @@ function Test-UpdatedSubmission
     )
     $submission = $submissionJson | ConvertFrom-Json -Depth 100
 
-    $applicationPackagesProperty = Get-PropertyByName `
-        -InputObject $submission `
-        -Name "ApplicationPackages"
-
-    if ($null -eq $applicationPackagesProperty)
-    {
-        throw "The updated submission does not contain ApplicationPackages."
-    }
-
     $expectedPackageName = [IO.Path]::GetFileName($StorePackagePath)
-    $packageMatch = $null
-
-    foreach ($applicationPackage in @($applicationPackagesProperty.Value))
-    {
-        $fileNameProperty = Get-PropertyByName `
-            -InputObject $applicationPackage `
-            -Name "FileName"
-
-        if ($null -ne $fileNameProperty -and
-            [string]$fileNameProperty.Value -ieq $expectedPackageName)
-        {
-            $packageMatch = $applicationPackage
-            break
-        }
-    }
+    $packageMatch = Get-ApplicationPackage `
+        -Submission $submission `
+        -FileName $expectedPackageName
 
     if ($null -eq $packageMatch)
     {
@@ -185,21 +345,15 @@ function Test-UpdatedSubmission
 
     Write-Host "Verified Store package in submission: $expectedPackageName"
 
-    $listingsProperty = Get-PropertyByName `
-        -InputObject $submission `
-        -Name "Listings"
-
-    if ($null -eq $listingsProperty)
-    {
-        throw "The updated submission does not contain Listings."
-    }
-
     $localeConfiguration = Get-Content -LiteralPath $StoreLocalesPath -Raw | ConvertFrom-Json -Depth 10
     $locales = @($localeConfiguration.PSObject.Properties["locales"].Value)
+    $submissionListings = Assert-SubmissionLocales `
+        -Submission $submission `
+        -ConfiguredLocales $locales
 
     foreach ($locale in $locales)
     {
-        $submissionListing = $listingsProperty.Value.PSObject.Properties |
+        $submissionListing = $submissionListings.PSObject.Properties |
             Where-Object { $_.Name.Equals($locale, [StringComparison]::OrdinalIgnoreCase) } |
             Select-Object -First 1
 
@@ -228,7 +382,10 @@ function Test-UpdatedSubmission
 
             if ($null -eq $updatedProperty)
             {
-                throw "The updated '$locale' listing does not contain '$($property.Name)'."
+                $expectedValue = ConvertTo-ComparableJson -Value $property.Value
+                throw @"
+The updated '$locale' listing does not contain '$($property.Name)'. Expected: $expectedValue. Actual: <missing>.
+"@
             }
 
             $expectedValue = ConvertTo-ComparableJson -Value $property.Value
@@ -236,11 +393,53 @@ function Test-UpdatedSubmission
 
             if ($expectedValue -cne $actualValue)
             {
-                throw "The updated '$locale' listing property '$($property.Name)' does not match the repository listing."
+                throw @"
+The updated '$locale' listing property '$($property.Name)' does not match the repository listing. Expected: $expectedValue. Actual: $actualValue.
+"@
             }
         }
 
         Write-Host "Verified Store listing in submission: $locale"
+    }
+}
+
+function Wait-MicrosoftStoreSubmissionVerification
+{
+    $deadline = [DateTime]::UtcNow.AddSeconds($SubmissionVerificationTimeoutSeconds)
+    $delaySeconds = 5
+    $attempt = 0
+    $lastError = "The Store submission has not been verified."
+
+    while ($true)
+    {
+        $attempt++
+
+        try
+        {
+            Test-UpdatedSubmission
+            Write-Host "Verified the updated Store submission after $attempt attempt(s)."
+            return
+        }
+        catch
+        {
+            $lastError = $_.Exception.Message
+        }
+
+        $remainingSeconds = [int][Math]::Floor(
+            ($deadline - [DateTime]::UtcNow).TotalSeconds
+        )
+
+        if ($remainingSeconds -le 0)
+        {
+            throw "Timed out verifying the Store submission after $attempt attempt(s). Last error: $lastError"
+        }
+
+        $sleepSeconds = [Math]::Min($delaySeconds, $remainingSeconds)
+        Write-Warning @"
+Store submission verification attempt $attempt failed: $lastError Retrying in $sleepSeconds second(s).
+"@
+        Start-Sleep -Seconds $sleepSeconds
+        $delaySeconds = [Math]::Min($delaySeconds * 2, 30)
     }
 }
 
@@ -382,11 +581,7 @@ try
 {
     $submissionPath = Join-Path $tempPath "submission.json"
     $updatedSubmissionPath = Join-Path $tempPath "submission.updated.json"
-    $submissionJson = Invoke-MsStoreJson -Arguments @(
-        "submission",
-        "get",
-        $PartnerCenterStoreId
-    )
+    $submissionJson = Wait-MicrosoftStorePackageValidation
     [IO.File]::WriteAllText(
         $submissionPath,
         $submissionJson + [Environment]::NewLine,
@@ -409,26 +604,7 @@ try
         $updatedMetadata
     )
 
-    $verificationAttempts = 3
-
-    for ($attempt = 1; $attempt -le $verificationAttempts; $attempt++)
-    {
-        try
-        {
-            Test-UpdatedSubmission
-            break
-        }
-        catch
-        {
-            if ($attempt -eq $verificationAttempts)
-            {
-                throw
-            }
-
-            Write-Warning "Store submission verification attempt $attempt failed: $($_.Exception.Message). Retrying."
-            Start-Sleep -Seconds 5
-        }
-    }
+    Wait-MicrosoftStoreSubmissionVerification
 
     if (-not $Submit)
     {

--- a/.github/scripts/SubmitTo-MicrosoftStore.ps1
+++ b/.github/scripts/SubmitTo-MicrosoftStore.ps1
@@ -620,12 +620,16 @@ try
         throw "The pending Store submission could not be retrieved."
     }
 
+    $validationSubmission = $submissionJson | ConvertFrom-Json -Depth 100
+    $validationSubmissionJson = $validationSubmission |
+        ConvertTo-Json -Depth 100 -Compress
+
     Write-Host "Requesting Partner Center package validation for '$expectedPackageName'."
     Invoke-MsStore -Arguments @(
         "submission",
         "updateMetadata",
         $PartnerCenterStoreId,
-        $submissionJson
+        $validationSubmissionJson
     )
 
     $submissionJson = Wait-MicrosoftStorePackageValidation

--- a/.github/scripts/SubmitTo-MicrosoftStore.ps1
+++ b/.github/scripts/SubmitTo-MicrosoftStore.ps1
@@ -39,8 +39,9 @@ param(
 
     [string]$PackageRolloutPercentage = "",
 
+    [Alias("PackageValidationTimeoutSeconds")]
     [ValidateRange(1, 3600)]
-    [int]$PackageValidationTimeoutSeconds = 900,
+    [int]$PackageReadinessTimeoutSeconds = 300,
 
     [ValidateRange(1, 3600)]
     [int]$SubmissionVerificationTimeoutSeconds = 300
@@ -232,10 +233,10 @@ function Assert-SubmissionLocales
     return $listingsProperty.Value
 }
 
-function Wait-MicrosoftStorePackageValidation
+function Wait-MicrosoftStorePackageReadiness
 {
     $expectedPackageName = [IO.Path]::GetFileName($StorePackagePath)
-    $deadline = [DateTime]::UtcNow.AddSeconds($PackageValidationTimeoutSeconds)
+    $deadline = [DateTime]::UtcNow.AddSeconds($PackageReadinessTimeoutSeconds)
     $delaySeconds = 5
     $attempt = 0
     $lastError = "The package has not been returned by Partner Center."
@@ -268,8 +269,12 @@ function Wait-MicrosoftStorePackageValidation
                 $languagesProperty = Get-PropertyByName `
                     -InputObject $applicationPackage `
                     -Name "Languages"
+                $fileStatusProperty = Get-PropertyByName `
+                    -InputObject $applicationPackage `
+                    -Name "FileStatus"
                 $version = ""
                 $languages = @()
+                $fileStatus = ""
 
                 if ($null -ne $versionProperty)
                 {
@@ -287,17 +292,31 @@ function Wait-MicrosoftStorePackageValidation
                     )
                 }
 
-                if (-not [string]::IsNullOrWhiteSpace($version) -and
+                if ($null -ne $fileStatusProperty)
+                {
+                    $fileStatus = [string]$fileStatusProperty.Value
+                }
+
+                if ($fileStatus -ieq "PendingUpload")
+                {
+                    Write-Host @"
+Store package is staged in the draft: $expectedPackageName (fileStatus=$fileStatus). Version and languages will be populated when Partner Center processes the committed submission.
+"@
+                    return $submissionJson
+                }
+
+                if ($fileStatus -ieq "Uploaded" -and
+                    -not [string]::IsNullOrWhiteSpace($version) -and
                     $languages.Count -gt 0)
                 {
                     Write-Host @"
-Store package validation completed: $expectedPackageName (version=$version, languages=$($languages.Count)).
+Store package validation completed: $expectedPackageName (fileStatus=$fileStatus, version=$version, languages=$($languages.Count)).
 "@
                     return $submissionJson
                 }
 
                 $lastError = @"
-Partner Center has not finished validating '$expectedPackageName' (version='$version', languages=$($languages.Count)).
+Partner Center has not staged '$expectedPackageName' (fileStatus='$fileStatus', version='$version', languages=$($languages.Count)).
 "@.Trim()
             }
         }
@@ -312,12 +331,12 @@ Partner Center has not finished validating '$expectedPackageName' (version='$ver
 
         if ($remainingSeconds -le 0)
         {
-            throw "Timed out waiting for Store package validation after $attempt attempt(s). Last result: $lastError"
+            throw "Timed out waiting for Store package readiness after $attempt attempt(s). Last result: $lastError"
         }
 
         $sleepSeconds = [Math]::Min($delaySeconds, $remainingSeconds)
         Write-Warning @"
-Store package validation attempt $attempt is not ready: $lastError Retrying in $sleepSeconds second(s).
+Store package readiness attempt $attempt is not ready: $lastError Retrying in $sleepSeconds second(s).
 "@
         Start-Sleep -Seconds $sleepSeconds
         $delaySeconds = [Math]::Min($delaySeconds * 2, 30)
@@ -632,7 +651,7 @@ try
         $validationSubmissionJson
     )
 
-    $submissionJson = Wait-MicrosoftStorePackageValidation
+    $submissionJson = Wait-MicrosoftStorePackageReadiness
     [IO.File]::WriteAllText(
         $submissionPath,
         $submissionJson + [Environment]::NewLine,

--- a/.github/scripts/Validate-MicrosoftStoreListings.ps1
+++ b/.github/scripts/Validate-MicrosoftStoreListings.ps1
@@ -134,6 +134,16 @@ if ([string]::IsNullOrWhiteSpace($defaultLocale))
     throw "The Microsoft Store defaultLocale must be specified."
 }
 
+for ($localeIndex = 0; $localeIndex -lt $locales.Count; $localeIndex++)
+{
+    $locale = $locales[$localeIndex]
+
+    if ($locale -isnot [string] -or [string]::IsNullOrWhiteSpace($locale))
+    {
+        throw "The Microsoft Store locale at index $localeIndex must be a non-empty string."
+    }
+}
+
 if ($locales -inotcontains $defaultLocale)
 {
     throw "The Microsoft Store defaultLocale must be included in locales."

--- a/.github/scripts/Validate-MicrosoftStoreListings.ps1
+++ b/.github/scripts/Validate-MicrosoftStoreListings.ps1
@@ -1,0 +1,255 @@
+# Copyright (c) 2026 0x5BFA
+# Licensed under the MIT License. See the LICENSE.
+
+#Requires -Version 7.4
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$ListingsPath,
+
+    [Parameter(Mandatory)]
+    [string]$LocalesPath
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 3.0
+
+$allowedProperties = @(
+    "description",
+    "shortDescription",
+    "features",
+    "keywords",
+    "releaseNotes",
+    "shortTitle",
+    "voiceTitle",
+    "devStudio",
+    "copyrightAndTrademarkInfo",
+    "licenseTerms",
+    "recommendedHardware",
+    "minimumHardware"
+)
+
+function Assert-StringLength
+{
+    param(
+        [Parameter(Mandatory)]
+        [string]$Locale,
+
+        [Parameter(Mandatory)]
+        [string]$PropertyName,
+
+        [AllowEmptyString()]
+        [string]$Value,
+
+        [Parameter(Mandatory)]
+        [int]$MaximumLength,
+
+        [switch]$Required
+    )
+
+    if ($Required -and [string]::IsNullOrWhiteSpace($Value))
+    {
+        throw "$Locale.$PropertyName must not be empty."
+    }
+
+    if ($Value.Length -gt $MaximumLength)
+    {
+        throw "$Locale.$PropertyName exceeds the $MaximumLength character limit."
+    }
+}
+
+function Assert-StringArray
+{
+    param(
+        [Parameter(Mandatory)]
+        [string]$Locale,
+
+        [Parameter(Mandatory)]
+        [string]$PropertyName,
+
+        [AllowEmptyCollection()]
+        [object[]]$Values,
+
+        [Parameter(Mandatory)]
+        [int]$MaximumItems,
+
+        [Parameter(Mandatory)]
+        [int]$MaximumItemLength
+    )
+
+    if ($Values.Count -gt $MaximumItems)
+    {
+        throw "$Locale.$PropertyName exceeds the $MaximumItems item limit."
+    }
+
+    foreach ($value in $Values)
+    {
+        if ($value -isnot [string] -or [string]::IsNullOrWhiteSpace($value))
+        {
+            throw "$Locale.$PropertyName must contain only non-empty strings."
+        }
+
+        if ($value.Length -gt $MaximumItemLength)
+        {
+            throw "$Locale.$PropertyName contains an item longer than $MaximumItemLength characters."
+        }
+    }
+}
+
+if (-not (Test-Path -LiteralPath $ListingsPath -PathType Container))
+{
+    throw "The Store listings directory does not exist: $ListingsPath"
+}
+
+if (-not (Test-Path -LiteralPath $LocalesPath -PathType Leaf))
+{
+    throw "The Store locales file does not exist: $LocalesPath"
+}
+
+$localeConfiguration = Get-Content -LiteralPath $LocalesPath -Raw | ConvertFrom-Json -Depth 10
+$localesProperty = $localeConfiguration.PSObject.Properties["locales"]
+$defaultLocaleProperty = $localeConfiguration.PSObject.Properties["defaultLocale"]
+
+if ($null -eq $localesProperty)
+{
+    throw "The Microsoft Store locales file must contain a locales array."
+}
+
+if ($null -eq $defaultLocaleProperty)
+{
+    throw "The Microsoft Store locales file must contain defaultLocale."
+}
+
+$locales = @($localesProperty.Value)
+$defaultLocale = [string]$defaultLocaleProperty.Value
+
+if ($locales.Count -eq 0)
+{
+    throw "At least one Microsoft Store locale must be enabled."
+}
+
+if ([string]::IsNullOrWhiteSpace($defaultLocale))
+{
+    throw "The Microsoft Store defaultLocale must be specified."
+}
+
+if ($locales -inotcontains $defaultLocale)
+{
+    throw "The Microsoft Store defaultLocale must be included in locales."
+}
+
+$normalizedLocales = @($locales | ForEach-Object { $_.ToLowerInvariant() })
+
+if (@($normalizedLocales | Select-Object -Unique).Count -ne $locales.Count)
+{
+    throw "The Microsoft Store locales list contains duplicates."
+}
+
+foreach ($locale in $locales)
+{
+    if ($locale -notmatch "^[a-z]{2,3}(?:-[A-Za-z0-9]{2,8})+$")
+    {
+        throw "The Microsoft Store locale '$locale' is not a supported locale format."
+    }
+
+    $listingPath = Join-Path $ListingsPath "$locale.json"
+
+    if (-not (Test-Path -LiteralPath $listingPath -PathType Leaf))
+    {
+        throw "The Store listing for '$locale' does not exist: $listingPath"
+    }
+
+    $listing = Get-Content -LiteralPath $listingPath -Raw | ConvertFrom-Json -Depth 20
+    $unknownProperties = @(
+        $listing.PSObject.Properties.Name |
+            Where-Object { $allowedProperties -notcontains $_ }
+    )
+
+    if ($unknownProperties.Count -gt 0)
+    {
+        throw "$locale contains unsupported properties: $($unknownProperties -join ', ')."
+    }
+
+    $descriptionProperty = $listing.PSObject.Properties["description"]
+
+    if ($null -eq $descriptionProperty -or $descriptionProperty.Value -isnot [string])
+    {
+        throw "$locale.description must be a string."
+    }
+
+    Assert-StringLength -Locale $locale -PropertyName "description" `
+        -Value $descriptionProperty.Value -MaximumLength 10000 -Required
+
+    $stringLimits = @{
+        shortDescription             = 1000
+        releaseNotes                 = 1500
+        shortTitle                   = 50
+        voiceTitle                   = 255
+        devStudio                    = 255
+        copyrightAndTrademarkInfo    = 200
+        licenseTerms                 = 10000
+    }
+
+    foreach ($entry in $stringLimits.GetEnumerator())
+    {
+        $property = $listing.PSObject.Properties[$entry.Key]
+
+        if ($null -eq $property)
+        {
+            continue
+        }
+
+        if ($property.Value -isnot [string])
+        {
+            throw "$locale.$($entry.Key) must be a string."
+        }
+
+        Assert-StringLength -Locale $locale -PropertyName $entry.Key `
+            -Value $property.Value -MaximumLength $entry.Value
+    }
+
+    $arrayLimits = @{
+        features                = @(20, 200)
+        keywords                = @(7, 40)
+        recommendedHardware     = @(11, 200)
+        minimumHardware         = @(11, 200)
+    }
+
+    foreach ($entry in $arrayLimits.GetEnumerator())
+    {
+        $property = $listing.PSObject.Properties[$entry.Key]
+
+        if ($null -eq $property)
+        {
+            continue
+        }
+
+        if ($property.Value -is [string] -or $property.Value -isnot [Collections.IEnumerable])
+        {
+            throw "$locale.$($entry.Key) must be an array."
+        }
+
+        Assert-StringArray -Locale $locale -PropertyName $entry.Key `
+            -Values @($property.Value) `
+            -MaximumItems $entry.Value[0] `
+            -MaximumItemLength $entry.Value[1]
+    }
+
+    $keywordsProperty = $listing.PSObject.Properties["keywords"]
+
+    if ($null -ne $keywordsProperty)
+    {
+        $keywordWordCount = [regex]::Matches(
+            (@($keywordsProperty.Value) -join " "),
+            "\S+"
+        ).Count
+
+        if ($keywordWordCount -gt 21)
+        {
+            throw "$locale.keywords exceeds the 21 word limit."
+        }
+    }
+}
+
+Write-Host "Validated $($locales.Count) Microsoft Store listing(s): $($locales -join ', ')"

--- a/.github/workflows/cd-store.yml
+++ b/.github/workflows/cd-store.yml
@@ -7,12 +7,21 @@ on:
   workflow_dispatch:
     inputs:
       submit:
-        description: 'Submit the package to Microsoft Store certification. When false, the submission stays as a draft.'
+        description: 'Submit the prepared draft to Microsoft Store certification.'
         required: true
         default: false
         type: boolean
+      replace_existing_draft:
+        description: 'Replace an existing Partner Center draft. Keep disabled unless that draft can be discarded.'
+        required: true
+        default: false
+        type: boolean
+      release_notes:
+        description: 'Optional English release notes. When empty, the existing Store value is preserved.'
+        required: false
+        type: string
       flight_id:
-        description: 'Optional Microsoft Store flight ID.'
+        description: 'Optional Microsoft Store flight ID. Store listings are not updated for flights.'
         required: false
         type: string
       rollout_percentage:
@@ -25,25 +34,25 @@ run-name: 'FluentHub CD (Store)'
 permissions:
   contents: read
 
+concurrency:
+  group: microsoft-store-production
+  cancel-in-progress: false
+
 jobs:
   build:
     if: github.repository_owner == '0x5bfa'
     runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        configuration: [Release] # Consider to use Store
-        platform: [x64]
     env:
       APPX_BUNDLE_PLATFORMS:         'x64|arm64'
-      CONFIGURATION:                 '${{ matrix.configuration }}'
-      PLATFORM:                      '${{ matrix.platform }}'
-      WORKING_DIR:                   '${{ github.workspace }}' # Default: 'D:\a\FluentHub\FluentHub'
+      CONFIGURATION:                 'Release'
+      PLATFORM:                      'x64'
+      WORKING_DIR:                   '${{ github.workspace }}'
       APP_PACKAGE_DIR:               '${{ github.workspace }}\src\FluentHub.App\AppPackages\'
       APP_PROJECT_PATH:              '${{ github.workspace }}\src\FluentHub.App\FluentHub.App.csproj'
       APP_MANIFEST_PATH:             '${{ github.workspace }}\src\FluentHub.App\Package.appxmanifest'
       APP_CREDENTIALS_PATH:          '${{ github.workspace }}\src\FluentHub.App\AppCredentials.config'
-      STORE_PRODUCT_ID:              "${{ vars.MICROSOFT_STORE_PRODUCT_ID || '9NKB9HX8RJZ3' }}"
+      STORE_LISTINGS_DIR:            '${{ github.workspace }}\Packaging\MicrosoftStore\Listings'
+      STORE_LOCALES_PATH:            '${{ github.workspace }}\Packaging\MicrosoftStore\locales.json'
 
     steps:
     - name: Checkout the repository
@@ -55,12 +64,20 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
 
-    - name: Build & package FluentHub
+    - name: Validate Microsoft Store listings
+      shell: pwsh
+      run: |
+        & "$env:WORKING_DIR\.github\scripts\Validate-MicrosoftStoreListings.ps1" `
+          -ListingsPath $env:STORE_LISTINGS_DIR `
+          -LocalesPath $env:STORE_LOCALES_PATH
+
+    - name: Build and package FluentHub
+      shell: pwsh
       run: |
         $bytes = [Convert]::FromBase64String($env:GH_CREDENTIALS_SECRET)
         [IO.File]::WriteAllBytes($env:APP_CREDENTIALS_PATH, $bytes)
 
-        cd $env:WORKING_DIR\src
+        Set-Location "$env:WORKING_DIR\src"
 
         & "$env:WORKING_DIR\.github\scripts\Build-App.ps1" `
           -Platform $env:PLATFORM `
@@ -70,8 +87,7 @@ jobs:
       env:
         GH_CREDENTIALS_SECRET: '${{ secrets.GH_CREDENTIALS_JSON_BASE64 }}'
 
-    - name: Find Store package
-      id: package
+    - name: Verify Store package
       shell: pwsh
       run: |
         $package = Get-ChildItem -Path $env:APP_PACKAGE_DIR -Recurse -File -Include *.msixupload, *.msixbundle, *.msix |
@@ -99,35 +115,96 @@ jobs:
           throw "No Store package was found under '$env:APP_PACKAGE_DIR'."
         }
 
-        "package_path=$($package.FullName)" >> $env:GITHUB_OUTPUT
-        "package_name=$($package.Name)" >> $env:GITHUB_OUTPUT
         Write-Host "Found Store package: $($package.FullName)"
 
-    - name: Upload the packages to the Artifacts
+    - name: Upload the Store package
       uses: actions/upload-artifact@v4
       with:
-        name: 'Appx Packages (${{ env.CONFIGURATION }}, ${{ env.PLATFORM }})'
+        name: FluentHub Store package
         path: ${{ env.APP_PACKAGE_DIR }}
         if-no-files-found: error
+        retention-days: 14
 
-    - name: Setup Microsoft Store Developer CLI
-      uses: microsoft/microsoft-store-apppublisher@v1.2
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: microsoft-store
+    env:
+      STORE_ARTIFACT_DIR:             '${{ github.workspace }}/artifacts/store'
+      STORE_LISTINGS_DIR:             '${{ github.workspace }}/Packaging/MicrosoftStore/Listings'
+      STORE_LOCALES_PATH:             '${{ github.workspace }}/Packaging/MicrosoftStore/locales.json'
+      STORE_PRODUCT_ID:               "${{ vars.MICROSOFT_STORE_PRODUCT_ID || '9NKB9HX8RJZ3' }}"
+      STORE_RELEASE_NOTES:            '${{ inputs.release_notes }}'
+      STORE_FLIGHT_ID:                '${{ inputs.flight_id }}'
+      STORE_ROLLOUT_PERCENTAGE:       '${{ inputs.rollout_percentage }}'
 
-    - name: Publish to Microsoft Store
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v4
+
+    - name: Download the Store package
+      uses: actions/download-artifact@v4
+      with:
+        name: FluentHub Store package
+        path: ${{ env.STORE_ARTIFACT_DIR }}
+
+    - name: Find Store package
+      id: package
       shell: pwsh
       run: |
-        $submit = [System.Convert]::ToBoolean("${{ inputs.submit }}")
+        $package = Get-ChildItem -Path $env:STORE_ARTIFACT_DIR -Recurse -File -Include *.msixupload, *.msixbundle, *.msix |
+          Sort-Object `
+            @{
+              Expression = {
+                switch ($_.Extension.ToLowerInvariant())
+                {
+                  ".msixupload" { 0 }
+                  ".msixbundle" { 1 }
+                  ".msix" { 2 }
+                  default { 3 }
+                }
+              }
+              Ascending = $true
+            },
+            @{
+              Expression = "LastWriteTimeUtc"
+              Descending = $true
+            } |
+          Select-Object -First 1
 
-        & "$env:WORKING_DIR\.github\scripts\SubmitTo-MicrosoftStore.ps1" `
+        if ($null -eq $package)
+        {
+          throw "No Store package was found under '$env:STORE_ARTIFACT_DIR'."
+        }
+
+        "package_path=$($package.FullName)" >> $env:GITHUB_OUTPUT
+        Write-Host "Found Store package: $($package.FullName)"
+
+    - name: Setup Microsoft Store Developer CLI
+      uses: microsoft/microsoft-store-apppublisher@cc9910a8d59f2eb55cbb83df0a3800cf3b5300e0
+      with:
+        version: v0.3.9
+
+    - name: Prepare and publish Microsoft Store submission
+      shell: pwsh
+      run: |
+        $submit = [Convert]::ToBoolean("${{ inputs.submit }}")
+        $replaceExistingDraft = [Convert]::ToBoolean("${{ inputs.replace_existing_draft }}")
+
+        & "${{ github.workspace }}/.github/scripts/SubmitTo-MicrosoftStore.ps1" `
           -StorePackagePath "${{ steps.package.outputs.package_path }}" `
+          -StoreListingsPath $env:STORE_LISTINGS_DIR `
+          -StoreLocalesPath $env:STORE_LOCALES_PATH `
           -PartnerCenterClientId $env:PARTNER_CENTER_CLIENT_ID `
           -PartnerCenterClientSecret $env:PARTNER_CENTER_CLIENT_SECRET `
           -PartnerCenterSellerId $env:PARTNER_CENTER_SELLER_ID `
           -PartnerCenterStoreId $env:STORE_PRODUCT_ID `
           -PartnerCenterTenantId $env:PARTNER_CENTER_TENANT_ID `
           -Submit:$submit `
-          -FlightId "${{ inputs.flight_id }}" `
-          -PackageRolloutPercentage "${{ inputs.rollout_percentage }}"
+          -ReplaceExistingDraft:$replaceExistingDraft `
+          -ReleaseNotes $env:STORE_RELEASE_NOTES `
+          -FlightId $env:STORE_FLIGHT_ID `
+          -PackageRolloutPercentage $env:STORE_ROLLOUT_PERCENTAGE
       env:
         PARTNER_CENTER_CLIENT_ID: ${{ secrets.PARTNER_CENTER_CLIENT_ID }}
         PARTNER_CENTER_CLIENT_SECRET: ${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}

--- a/.github/workflows/cd-store.yml
+++ b/.github/workflows/cd-store.yml
@@ -198,30 +198,11 @@ jobs:
     - name: Prepare and publish Microsoft Store submission
       shell: bash
       run: |
-        dbus-run-session -- bash -euo pipefail <<'BASH'
-        keyring_env="$(printf '\n' | gnome-keyring-daemon --unlock)"
-        eval "$keyring_env"
-
-        pwsh -NoLogo -NoProfile -Command - <<'POWERSHELL'
-        $submit = [Convert]::ToBoolean($env:STORE_SUBMIT)
-        $replaceExistingDraft = [Convert]::ToBoolean($env:STORE_REPLACE_EXISTING_DRAFT)
-
-        & "$env:GITHUB_WORKSPACE/.github/scripts/SubmitTo-MicrosoftStore.ps1" `
-          -StorePackagePath $env:STORE_PACKAGE_PATH `
-          -StoreListingsPath $env:STORE_LISTINGS_DIR `
-          -StoreLocalesPath $env:STORE_LOCALES_PATH `
-          -PartnerCenterClientId $env:PARTNER_CENTER_CLIENT_ID `
-          -PartnerCenterClientSecret $env:PARTNER_CENTER_CLIENT_SECRET `
-          -PartnerCenterSellerId $env:PARTNER_CENTER_SELLER_ID `
-          -PartnerCenterStoreId $env:STORE_PRODUCT_ID `
-          -PartnerCenterTenantId $env:PARTNER_CENTER_TENANT_ID `
-          -Submit:$submit `
-          -ReplaceExistingDraft:$replaceExistingDraft `
-          -ReleaseNotes $env:STORE_RELEASE_NOTES `
-          -FlightId $env:STORE_FLIGHT_ID `
-          -PackageRolloutPercentage $env:STORE_ROLLOUT_PERCENTAGE
-        POWERSHELL
-        BASH
+        dbus-run-session -- bash -euo pipefail -c '
+          keyring_env="$(printf '\''\n'\'' | gnome-keyring-daemon --unlock)"
+          eval "$keyring_env"
+          pwsh -NoLogo -NoProfile -File "$GITHUB_WORKSPACE/.github/scripts/Run-MicrosoftStoreSubmission.ps1"
+        '
       env:
         STORE_PACKAGE_PATH: ${{ steps.package.outputs.package_path }}
         STORE_SUBMIT: ${{ inputs.submit }}

--- a/.github/workflows/cd-store.yml
+++ b/.github/workflows/cd-store.yml
@@ -185,14 +185,29 @@ jobs:
       with:
         version: v0.3.9
 
-    - name: Prepare and publish Microsoft Store submission
-      shell: pwsh
+    - name: Setup Linux credential store
+      shell: bash
       run: |
-        $submit = [Convert]::ToBoolean("${{ inputs.submit }}")
-        $replaceExistingDraft = [Convert]::ToBoolean("${{ inputs.replace_existing_draft }}")
+        sudo apt-get update
+        sudo apt-get install --yes --no-install-recommends \
+          dbus \
+          dbus-x11 \
+          gnome-keyring \
+          libsecret-1-0
 
-        & "${{ github.workspace }}/.github/scripts/SubmitTo-MicrosoftStore.ps1" `
-          -StorePackagePath "${{ steps.package.outputs.package_path }}" `
+    - name: Prepare and publish Microsoft Store submission
+      shell: bash
+      run: |
+        dbus-run-session -- bash -euo pipefail <<'BASH'
+        keyring_env="$(printf '\n' | gnome-keyring-daemon --unlock)"
+        eval "$keyring_env"
+
+        pwsh -NoLogo -NoProfile -Command - <<'POWERSHELL'
+        $submit = [Convert]::ToBoolean($env:STORE_SUBMIT)
+        $replaceExistingDraft = [Convert]::ToBoolean($env:STORE_REPLACE_EXISTING_DRAFT)
+
+        & "$env:GITHUB_WORKSPACE/.github/scripts/SubmitTo-MicrosoftStore.ps1" `
+          -StorePackagePath $env:STORE_PACKAGE_PATH `
           -StoreListingsPath $env:STORE_LISTINGS_DIR `
           -StoreLocalesPath $env:STORE_LOCALES_PATH `
           -PartnerCenterClientId $env:PARTNER_CENTER_CLIENT_ID `
@@ -205,7 +220,12 @@ jobs:
           -ReleaseNotes $env:STORE_RELEASE_NOTES `
           -FlightId $env:STORE_FLIGHT_ID `
           -PackageRolloutPercentage $env:STORE_ROLLOUT_PERCENTAGE
+        POWERSHELL
+        BASH
       env:
+        STORE_PACKAGE_PATH: ${{ steps.package.outputs.package_path }}
+        STORE_SUBMIT: ${{ inputs.submit }}
+        STORE_REPLACE_EXISTING_DRAFT: ${{ inputs.replace_existing_draft }}
         PARTNER_CENTER_CLIENT_ID: ${{ secrets.PARTNER_CENTER_CLIENT_ID }}
         PARTNER_CENTER_CLIENT_SECRET: ${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}
         PARTNER_CENTER_SELLER_ID: ${{ secrets.PARTNER_CENTER_SELLER_ID }}

--- a/.github/workflows/cd-store.yml
+++ b/.github/workflows/cd-store.yml
@@ -28,11 +28,16 @@ on:
         description: 'Optional package rollout percentage. Leave empty for the Store default.'
         required: false
         type: string
+      artifact_run_id:
+        description: 'Optional prior Store workflow run ID whose package artifact should be reused.'
+        required: false
+        type: string
 
 run-name: 'FluentHub CD (Store)'
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: microsoft-store-production
@@ -40,7 +45,7 @@ concurrency:
 
 jobs:
   build:
-    if: github.repository_owner == '0x5bfa'
+    if: github.repository_owner == '0x5bfa' && inputs.artifact_run_id == ''
     runs-on: windows-latest
     env:
       APPX_BUNDLE_PLATFORMS:         'x64|arm64'
@@ -127,6 +132,9 @@ jobs:
 
   deploy:
     needs: build
+    if: >-
+      always() &&
+      (needs.build.result == 'success' || needs.build.result == 'skipped')
     runs-on: ubuntu-latest
     environment: microsoft-store
     env:
@@ -147,6 +155,9 @@ jobs:
       with:
         name: FluentHub Store package
         path: ${{ env.STORE_ARTIFACT_DIR }}
+        github-token: ${{ github.token }}
+        repository: ${{ github.repository }}
+        run-id: ${{ inputs.artifact_run_id || github.run_id }}
 
     - name: Find Store package
       id: package

--- a/.github/workflows/cd-store.yml
+++ b/.github/workflows/cd-store.yml
@@ -206,7 +206,7 @@ jobs:
           gnome-keyring \
           libsecret-1-0
 
-    - name: Prepare and publish Microsoft Store submission
+    - name: Prepare Microsoft Store submission
       shell: bash
       run: |
         dbus-run-session -- bash -euo pipefail -c '

--- a/Packaging/MicrosoftStore/Listings/en-US.json
+++ b/Packaging/MicrosoftStore/Listings/en-US.json
@@ -1,0 +1,24 @@
+{
+  "description": "FluentHub is a modern GitHub client designed for Windows. Browse repositories, issues, pull requests, releases, and user profiles in a native Fluent Design interface. Work across multiple pages with tabs and keep your navigation history while you manage everyday GitHub tasks.",
+  "shortDescription": "A stylish yet powerful GitHub client designed for Windows.",
+  "features": [
+    "Native Windows experience built with WinUI 3",
+    "Browse repositories, issues, pull requests, releases, and profiles",
+    "Create and manage issues and pull requests",
+    "Work across multiple tabs",
+    "Navigate without losing history or progress"
+  ],
+  "keywords": [
+    "GitHub",
+    "Git",
+    "repository",
+    "issues",
+    "pull requests",
+    "developer",
+    "code"
+  ],
+  "shortTitle": "FluentHub",
+  "voiceTitle": "Fluent Hub",
+  "devStudio": "FluentHub",
+  "copyrightAndTrademarkInfo": "Copyright FluentHub contributors."
+}

--- a/Packaging/MicrosoftStore/README.md
+++ b/Packaging/MicrosoftStore/README.md
@@ -21,7 +21,12 @@ The Partner Center draft must contain exactly the locales listed in
 unmanaged locale remains enabled. This prevents an incomplete listing without
 source-controlled text and screenshots from blocking certification.
 
-After uploading a package, the workflow waits for Partner Center to expose its
-validated version and languages before updating listing metadata. It then
-verifies the persisted package and listing values with backoff for up to five
-minutes before leaving the submission as a draft or sending it to certification.
+After uploading a package, the workflow requests package validation and waits
+for Partner Center to expose its validated version and languages before updating
+listing metadata. Package validation uses backoff for up to 15 minutes; listing
+verification uses backoff for up to five minutes.
+
+If a run stops while the uploaded package is still being validated, rerun the
+workflow with `replace_existing_draft` disabled. When the existing draft contains
+the same package filename, the workflow resumes that draft instead of replacing
+it and resetting Partner Center processing.

--- a/Packaging/MicrosoftStore/README.md
+++ b/Packaging/MicrosoftStore/README.md
@@ -1,9 +1,8 @@
 # Microsoft Store listings
 
 `Listings` contains the localized, source-controlled fields that are merged into
-the current Partner Center draft by the Store deployment workflow. Dynamic
-submission fields, package state, and existing listing images remain owned by
-Partner Center.
+the current draft through the Store Submission API. Dynamic submission fields,
+package state, and existing listing images remain owned by Partner Center.
 
 `en-US.json` is the Crowdin source file. Crowdin translations can be enabled for
 Store publishing by adding their locale to `locales.json`.
@@ -21,16 +20,22 @@ The Partner Center draft must contain exactly the locales listed in
 unmanaged locale remains enabled. This prevents an incomplete listing without
 source-controlled text and screenshots from blocking certification.
 
-After uploading a package, the workflow updates the draft so Partner Center can
-associate the blob with its `PendingUpload` package entry. That status is the
-expected ready state for a `--noCommit` draft; Partner Center populates validated
-version and language values while processing a committed submission. The
-workflow waits with backoff for package readiness and then verifies listing
-persistence with backoff for up to five minutes.
+After uploading a package, `PendingUpload` is the expected staged state for a
+`--noCommit` draft. Partner Center populates validated version and language
+values while processing a committed submission. The workflow waits with backoff
+for package readiness and then verifies listing persistence with backoff for up
+to five minutes.
 
-If a run stops while the uploaded package is still being validated, rerun the
-workflow with `replace_existing_draft` disabled. When the existing draft contains
-the same package filename, the workflow resumes that draft instead of replacing
-it and resetting Partner Center processing. Set `artifact_run_id` to a prior
-Store workflow run whose build succeeded to reuse that run's package artifact
-and skip another package build while diagnosing or resuming a deployment.
+With `submit` disabled, verification is against the Store Submission API and the
+submission remains `PendingCommit`. The Partner Center editor can continue to
+show the previously committed package and listing values in this state. Enable
+`submit` only when the draft is ready to be committed to certification; the
+updated values become Store-visible after Partner Center finishes processing
+and certification.
+
+If a run stops after uploading a package, rerun the workflow with
+`replace_existing_draft` disabled. When the existing draft contains the same
+package filename, the workflow resumes that draft instead of replacing it. Set
+`artifact_run_id` to a prior Store workflow run whose build succeeded to reuse
+that run's package artifact and skip another package build while diagnosing or
+resuming a deployment.

--- a/Packaging/MicrosoftStore/README.md
+++ b/Packaging/MicrosoftStore/README.md
@@ -16,6 +16,12 @@ Before enabling a new locale:
 4. Add the exact locale to `locales.json`.
 5. Run the Store workflow with `submit` disabled and review the resulting draft.
 
-The workflow intentionally fails when a configured locale is missing from the
-Partner Center draft. This prevents an incomplete listing without screenshots
-from being submitted.
+The Partner Center draft must contain exactly the locales listed in
+`locales.json`. The workflow fails when a configured locale is missing or an
+unmanaged locale remains enabled. This prevents an incomplete listing without
+source-controlled text and screenshots from blocking certification.
+
+After uploading a package, the workflow waits for Partner Center to expose its
+validated version and languages before updating listing metadata. It then
+verifies the persisted package and listing values with backoff for up to five
+minutes before leaving the submission as a draft or sending it to certification.

--- a/Packaging/MicrosoftStore/README.md
+++ b/Packaging/MicrosoftStore/README.md
@@ -21,10 +21,12 @@ The Partner Center draft must contain exactly the locales listed in
 unmanaged locale remains enabled. This prevents an incomplete listing without
 source-controlled text and screenshots from blocking certification.
 
-After uploading a package, the workflow requests package validation and waits
-for Partner Center to expose its validated version and languages before updating
-listing metadata. Package validation uses backoff for up to 15 minutes; listing
-verification uses backoff for up to five minutes.
+After uploading a package, the workflow updates the draft so Partner Center can
+associate the blob with its `PendingUpload` package entry. That status is the
+expected ready state for a `--noCommit` draft; Partner Center populates validated
+version and language values while processing a committed submission. The
+workflow waits with backoff for package readiness and then verifies listing
+persistence with backoff for up to five minutes.
 
 If a run stops while the uploaded package is still being validated, rerun the
 workflow with `replace_existing_draft` disabled. When the existing draft contains

--- a/Packaging/MicrosoftStore/README.md
+++ b/Packaging/MicrosoftStore/README.md
@@ -29,4 +29,6 @@ verification uses backoff for up to five minutes.
 If a run stops while the uploaded package is still being validated, rerun the
 workflow with `replace_existing_draft` disabled. When the existing draft contains
 the same package filename, the workflow resumes that draft instead of replacing
-it and resetting Partner Center processing.
+it and resetting Partner Center processing. Set `artifact_run_id` to a prior
+Store workflow run whose build succeeded to reuse that run's package artifact
+and skip another package build while diagnosing or resuming a deployment.

--- a/Packaging/MicrosoftStore/README.md
+++ b/Packaging/MicrosoftStore/README.md
@@ -1,0 +1,21 @@
+# Microsoft Store listings
+
+`Listings` contains the localized, source-controlled fields that are merged into
+the current Partner Center draft by the Store deployment workflow. Dynamic
+submission fields, package state, and existing listing images remain owned by
+Partner Center.
+
+`en-US.json` is the Crowdin source file. Crowdin translations can be enabled for
+Store publishing by adding their locale to `locales.json`.
+
+Before enabling a new locale:
+
+1. Add the Store listing language in Partner Center.
+2. Upload at least one screenshot for that language.
+3. Ensure Crowdin has generated `Listings/<locale>.json`.
+4. Add the exact locale to `locales.json`.
+5. Run the Store workflow with `submit` disabled and review the resulting draft.
+
+The workflow intentionally fails when a configured locale is missing from the
+Partner Center draft. This prevents an incomplete listing without screenshots
+from being submitted.

--- a/Packaging/MicrosoftStore/listing.schema.json
+++ b/Packaging/MicrosoftStore/listing.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "FluentHub Microsoft Store listing",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "description"
+  ],
+  "properties": {
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 10000
+    },
+    "shortDescription": {
+      "type": "string",
+      "maxLength": 1000
+    },
+    "features": {
+      "type": "array",
+      "maxItems": 20,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200
+      }
+    },
+    "keywords": {
+      "type": "array",
+      "maxItems": 7,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 40
+      }
+    },
+    "releaseNotes": {
+      "type": "string",
+      "maxLength": 1500
+    },
+    "shortTitle": {
+      "type": "string",
+      "maxLength": 50
+    },
+    "voiceTitle": {
+      "type": "string",
+      "maxLength": 255
+    },
+    "devStudio": {
+      "type": "string",
+      "maxLength": 255
+    },
+    "copyrightAndTrademarkInfo": {
+      "type": "string",
+      "maxLength": 200
+    },
+    "licenseTerms": {
+      "type": "string",
+      "maxLength": 10000
+    },
+    "recommendedHardware": {
+      "type": "array",
+      "maxItems": 11,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200
+      }
+    },
+    "minimumHardware": {
+      "type": "array",
+      "maxItems": 11,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200
+      }
+    }
+  }
+}

--- a/Packaging/MicrosoftStore/locales.json
+++ b/Packaging/MicrosoftStore/locales.json
@@ -1,0 +1,6 @@
+{
+  "defaultLocale": "en-US",
+  "locales": [
+    "en-US"
+  ]
+}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -2,3 +2,5 @@ commit_message: 'Updated app translations by Crowdin'
 files:
   - source: /src/FluentHub.App/Strings/en-US/*.resw
     translation: /src/FluentHub.App/Strings/%locale%/%original_file_name%
+  - source: /Packaging/MicrosoftStore/Listings/en-US.json
+    translation: /Packaging/MicrosoftStore/Listings/%locale%.json


### PR DESCRIPTION
## Summary

- migrate the Store deployment workflow to Microsoft Store Developer CLI v0.3.9 through the official publisher action pinned by commit SHA
- separate Windows package creation from the protected `microsoft-store` deployment job, with concurrency control and draft-first publishing
- manage localized Store text as JSON under `Packaging/MicrosoftStore/Listings` and feed it through Crowdin
- merge source-controlled text into the current Partner Center submission while preserving packages, screenshots, and other dynamic metadata
- validate listing fields and Microsoft Store limits before packaging

## Safety

- submissions remain drafts unless `submit` is enabled
- an existing Partner Center draft stops the workflow unless `replace_existing_draft` is explicitly enabled, because the CLI replaces pending submissions
- only `en-US` is enabled initially; a new locale must first exist in Partner Center with screenshots
- flight submissions intentionally skip public listing metadata updates

## Required setup

- create/configure the `microsoft-store` GitHub Environment (approval protection is recommended)
- provide `PARTNER_CENTER_CLIENT_ID`, `PARTNER_CENTER_CLIENT_SECRET`, `PARTNER_CENTER_SELLER_ID`, and `PARTNER_CENTER_TENANT_ID`
- optionally set `MICROSOFT_STORE_PRODUCT_ID`; the current Store ID remains the fallback
- keep `GH_CREDENTIALS_JSON_BASE64` available to the build job

## Validation

- `actionlint` on `.github/workflows/cd-store.yml`
- PowerShell parser validation for all three Store scripts
- Store listing validation for `en-US`
- merge integration test preserving image and package metadata
- `dotnet restore FluentHub.slnx`
- `dotnet build FluentHub.slnx -c Debug --no-restore -v:minimal /clp:ErrorsOnly` (101 existing warnings, 0 errors; built with a temporary ignored dummy OAuth config)